### PR TITLE
Closed the call for speakers

### DIFF
--- a/cfp/views.py
+++ b/cfp/views.py
@@ -15,6 +15,7 @@ class CreateView(generic.CreateView):
     template_name = 'cfp/propose.html'
     form_class = CfpForm
     success_url = reverse_lazy('cfp:thanks')
+    http_method_names = ['get', 'options']  # POST disabled because cfp is closed
 
 
 class ThankYouView(generic.TemplateView):

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -223,3 +223,6 @@ footer .credits {
 .emojimode-toggler {
   cursor: pointer;
 }
+#closed {
+  font-size: 110%;
+}

--- a/static/css/style.less
+++ b/static/css/style.less
@@ -264,3 +264,7 @@ footer {
 .emojimode-toggler {
     cursor: pointer;
 }
+
+#closed {
+    font-size: 110%;
+}

--- a/templates/_about.html
+++ b/templates/_about.html
@@ -23,12 +23,10 @@
 
 <div class="row" id="cfp">
     <div class="col-md-12 text-center">
-        <h2>Become a speaker</h2>
-        <p>We want <strong>you</strong> to speak at DjangoCon!</p>
-        <p>Our call for speakers is open until <strong>January 14th 2016</strong>.</p>
-        <p>
-            <a href="{% url 'cfp:landing' %}" class="btn btn-lg btn-primary">Apply now!</a>
-        </p>
+        <h2>Speakers</h2>
+        <p>We have received a ton of really high quality submissions during our call for speakers (thanks to everyone who sent one!).</p>
+        <p>Our programming committee will now review all of them and make their selection.</p>
+        <p>We will start publishing accepted speakers on <strong>January 21st</strong>.</p>
     </div>
 </div>
 

--- a/templates/cfp/landing.html
+++ b/templates/cfp/landing.html
@@ -2,6 +2,13 @@
 
 {% block content %}
 
+<section id="closed" class="container">
+    <h1>Closed 🚫</h1>
+    <p><strong>Our call for speakers closed on January 14th</strong> so you it's not possible to submit a proposal anymore.</p>
+    <p>If you'd like to get in touch, please email us: <a href="mailto:2016@djangocon.eu">2016@djangocon.eu</a>.</p>
+    <p>We've left this page up for informational purposes only.</p>
+</section>
+
 <section class="container">
     <h1>Call for Speakers 📣</h1>
 

--- a/templates/cfp/propose.html
+++ b/templates/cfp/propose.html
@@ -3,6 +3,13 @@
 {% load bootstrap %}
 
 {% block content %}
+<section id="closed" class="container">
+    <h1>Closed 🚫</h1>
+    <p><strong>Our call for speakers closed on January 14th</strong> so you it's not possible to submit a proposal anymore.</p>
+    <p>If you'd like to get in touch, please email us: <a href="mailto:2016@djangocon.eu">2016@djangocon.eu</a>.</p>
+    <p>We've left this page up for informational purposes only.</p>
+</section>
+
 <div class="container">
     <h1>We want you to speak at DjangoCon</h1>
     <p>All the information you provide here is confidential and will only be shared within the organizing team.</p>
@@ -14,7 +21,8 @@
 <form action="{% url 'cfp:propose' %}" method="post" id="proposal" class="container">
     {{ form|bootstrap }}
     <p class="form-group text-center">
-        <button type="submit" class="btn btn-primary">Submit</button>
+        <button type="submit" class="btn btn-primary" disabled="disabled">Submit</button>
+        <a href="#closed">(the call for speakers is closed)</a>
     </p>
     {% csrf_token %}
 </form>


### PR DESCRIPTION
This should be merged once the CfP closes (23:59 CET on January 14th).

It disables the submission of new proposals and puts messages in various places indicating that the cfp has closed.
