### PR TITLE
Update twitter link.

### DIFF
--- a/templates/speakers/list.html
+++ b/templates/speakers/list.html
@@ -22,9 +22,7 @@
                     </a>
                 {% endif %}
                 {% if speaker.twitter %}
-                    <a class="toolbox" href="{{ speaker.twitter_link }}" title="@{{ speaker.twitter }}">
-                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                    </a>
+                    <a class="toolbox" href="{{ speaker.twitter_url }}" title="@{{ speaker.twitter }}"></a>
                 {% endif %}
             </div>
             <div>


### PR DESCRIPTION
It seems the twitter link is in a different variable. I have removed the pencil which is now appearing by the photo of a speaker even if you are not the staff user, but I am not sure what is the expected behaviour here. Should the photo be a link or should the icon be different in the toolbox for twitter?

I will update the PR upon your response :)
