### PR TITLE
Undo flex direction alternate on mobile for speakerlist

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -195,6 +195,11 @@ h4 {
 #speakers > .row.odd {
   flex-direction: row-reverse;
 }
+@media screen and (max-width: 768px) {
+  #speakers > .row.odd {
+    flex-direction: row;
+  }
+}
 #speakers .speaker .name {
   font-weight: bold;
 }

--- a/static/css/style.less
+++ b/static/css/style.less
@@ -237,6 +237,9 @@ h4 {
         }
         &.odd {
             flex-direction: row-reverse;
+            @media screen and (max-width:768px){
+                 flex-direction: row;
+            }
         }
     }
     .speaker {


### PR DESCRIPTION
This should at least partially fix #17 

The issue I'm seeing on mobile is that for even numbered speaker records, the descriptions are falling off the page. I believe this is due to Bootstrap not understanding how to handle `flex-direction: row-reverse`

So, for screens under 768px, I've added a setting to disable this flipping. From my limited testing, this appears to work on mobile devices, so much as I can actually read the list of speakers and their talks on a smaller screen, albeit with some horizontal scroll. 

Hope this helps! ✨
