### PR TITLE
Add glossary with basic concepts explained

### DIFF
--- a/djangocon/urls.py
+++ b/djangocon/urls.py
@@ -21,6 +21,7 @@ from djangocon import views
 urlpatterns = [
     url(r'^$', views.home, name='home'),
     url(r'^coc/$', views.coc, name='coc'),
+    url(r'^glossary/$', views.glossary, name='glossary'),
     url(r'^venue/$', views.venue, name='venue'),
     url(r'^live/$', views.live, name='live'),
     url(r'^cfp/', include('cfp.urls', namespace='cfp')),

--- a/djangocon/views.py
+++ b/djangocon/views.py
@@ -16,6 +16,9 @@ def home(request):
 def coc(request):
     return render(request, 'coc.html')
 
+def glossary(request):
+    return render(request, 'glossary.html')
+
 
 def venue(request):
     return render(request, 'venue.html')

--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -5,6 +5,7 @@
             <li class="col-md-2 col-sm-12"><a href="mailto:2016@djangocon.eu">2016&#8203;@djangocon.eu</a></li>
             <li class="col-md-2 col-sm-12"><a href="http://twitter.com/DjangoConEurope" data-emoji-alt="🐦">@DjangoCon&#8203;Europe</a></li>
             <li class="col-md-2 col-sm-12"><a href="{% url 'coc' %}">Code of Conduct</a></li>
+            <li class="col-md-2 col-sm-12"><a href="{% url 'glossary' %}" data-emoji-alt="📖">Glossary</a></li>
             <li class="col-md-2 col-sm-12"><a href="{% url 'cfp:landing' %}">CfP (closed)</a></li>
             <li class="col-md-2 col-sm-12"><a href="{% url 'organizers:list' %}" data-emoji-alt="👷">The Team</a></li>
         </ul>

--- a/templates/glossary.html
+++ b/templates/glossary.html
@@ -1,0 +1,37 @@
+{% extends 'base.html' %}
+{% load staticfiles %}
+
+{% block content %}
+
+<section id="dictionary" class="container">
+    <h1>
+        Glossary
+    </h1>
+    <p>
+        If you're not sure what all those specific to this conference concepts mean, we have your back! We gathered here terms that might be confusing. Do you think something is missing? Give us a hint at <a href="mailto:2016@djangocon.eu">2016&#8203;@djangocon.eu</a>.
+    </p>
+    <p>
+        <strong>CfP</strong> - Call for Paper - a way to call up and select speakers. Organisers ask people to submit their talk proposals or to nominate someone they want to see on a stage. Usually, there is a submission form to fill out. Afterwards, the submissions are anonymized and scored. The applicants that scored highest are invited to speak at a conference.
+    </p>
+    <p>
+        <strong>Djangonaut</strong> - a person working with Django.
+    </p>
+    <p>
+        <strong>Keynote</strong> - a talk from an invited speaker. Tends to be less technical and aims to be more inspirational, but that's not a hard rule. The keynote lecture is often longer, lasting sometimes up to an hour and a half.
+    </p>
+    <p>
+        <strong>Lightning talk</strong> - a 5min talk. Usually, lightning talks are at the end of the day. Subjects may vary: from an introduction to newest greatest tool speeding your work to quick workshop about how to eat a Tim Tam cookies properly. The only sure thing is a time limit. You have only five minutes. After those are up, presenter's microphone is disconnected and audience thanks the speaker with a roar of applause.
+    </p>
+    <p>
+        <strong>Sprint</strong> - that's the point in the schedule when we take out our computers and code together. Everyone is free to choose a subject that they want to work on. If you don't know what would you like to improve and in which project, you can join other people. Sprints are probably the best way to learn how to contribute to Django or your favorite open-source project.
+    </p>
+    <p>
+        <strong>Stroopwafels</strong> - wikipedia says: <em>stroopwafel is a waffle made from two thin layers of baked dough with a caramel-like syrup filling in the middle. It is popular in the Netherlands.</em> It is also a inside joke of Django community. It is unclear how this whole madness has started, but it was in full bloom in Amsterdam on the conference Django Under The Hood. There were 720 stroopwafels, including speaker gifts. That's 23 kg of stroopwafel, 104 million calories. Attendees loved stroopwafels so much that one of them even got sick from consuming too much. After hearing that, one of the DUTH organizers, who is dutch, looked suspicously self-satisfied.
+    </p>
+    <p>
+        <strong>TBA</strong> - short for To Be Announced.
+    </p>
+
+</section>
+
+{% endblock %}


### PR DESCRIPTION
For the first-time attendees some of the concepts that we use, like _lightning talk_ or _keynote_, can be unfamiliar. Also, we have some inside jokes that could be easily explained to newcomers and make them feel more welcome.
Of course, people can google stuff, but usually, a short friendly explanation is sufficient.

It's a little bit late and won't probably do much good this year, but maybe organizing team for DjangoCon EU 2017 could reuse this page.
